### PR TITLE
Changed navbar to sticky and added styles (didn't remove old styles)

### DIFF
--- a/web/app/themes/design102/assets/styles/common/_global.scss
+++ b/web/app/themes/design102/assets/styles/common/_global.scss
@@ -1,3 +1,11 @@
 body {
-  padding-top: 60px;
+  padding-top: 0px;
+}
+
+.sticky-top {
+  position:sticky;
+  left: 0;
+  right: 0;
+  top: 0;
+  z-index: 1030;
 }

--- a/web/app/themes/design102/header.php
+++ b/web/app/themes/design102/header.php
@@ -34,7 +34,7 @@ wp_body_open();
     <?php _e('You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.', 'sage'); ?>
 </div>
 <![endif]-->
-<nav class="navbar navbar-expand-md fixed-top navbar-light">
+<nav class="navbar navbar-expand-md sticky-top navbar-light">
     <div class="l-page-container">
         <a class="navbar-brand" href="<?= esc_url(home_url('/')); ?>">
             <img src="<?= Extras\asset_url('images/d102-logo.svg') ?>" alt="Design102"/>


### PR DESCRIPTION
- Removed the top padding to the body element
- Changed the navbar class to `sticky-top` from `fixed-top`
- Added new styles for the navbar so it behaves stickily, which puts it beneath the cookie banner.